### PR TITLE
Shelljoin on windows correctly

### DIFF
--- a/lib/vagrant-wrapper.rb
+++ b/lib/vagrant-wrapper.rb
@@ -175,10 +175,15 @@ class VagrantWrapper
 
   def shelljoin(args)
     if windows?
-      args.join(' ')
+      args.collect { |arg| dos_escape(arg) }.join(' ')
     else
       Shellwords.join(args)
     end
+  end
+
+  # borrowed from https://github.com/rubyworks/facets/issues/17
+  def dos_escape(cmdline)
+    '"' + cmdline.gsub(/\\(?=\\*\")/, "\\\\\\").gsub(/\"/, "\\\"").gsub(/\\$/, "\\\\\\").gsub("%", "%%") + '"'
   end
 
   def windows?

--- a/lib/vagrant-wrapper.rb
+++ b/lib/vagrant-wrapper.rb
@@ -159,7 +159,7 @@ class VagrantWrapper
       return nil
     end
     args.unshift(vagrant)
-    %x{#{Shellwords.join(args)} 2>&1}
+    %x{#{shelljoin(args)} 2>&1}
   end
 
   # Give execution control to Vagrant.
@@ -170,7 +170,15 @@ class VagrantWrapper
       exit(1)
     end
     args.unshift(vagrant)
-    exec(Shellwords.join(args))
+    exec(shelljoin(args))
+  end
+
+  def shelljoin(args)
+    if windows?
+      args.join(' ')
+    else
+      Shellwords.join(args)
+    end
   end
 
   def windows?

--- a/spec/vagrant_wrapper_spec.rb
+++ b/spec/vagrant_wrapper_spec.rb
@@ -200,6 +200,19 @@ describe VagrantWrapper do
       expect(@v.send(:windows?)).to be false
     end
   end
+
+  describe "#shelljoin" do
+    it "escapes properly on windows" do
+      stub_const("RUBY_PLATFORM", "i386-mingw32")
+      expect(@v.send(:shelljoin, ["up", "--no-provision", "--provider=virtualbox"]))
+        .to eq "\"up\" \"--no-provision\" \"--provider=virtualbox\""
+    end
+    it "escapes properly on linux" do
+      stub_const("RUBY_PLATFORM", "x86_64-linux")
+      expect(@v.send(:shelljoin, ["up", "--no-provision", "--provider=virtualbox"]))
+        .to eq "up --no-provision --provider\\=virtualbox"
+    end
+  end
 end
 
 describe "bin/vagrant" do


### PR DESCRIPTION
I noticed that vagrant-wrapper 
- works correctly if you run `vagrant up --provider virtualbox`
- fails if you run `vagrant up --provider=virtualbox` (notice the `=`)

The error I get with vagrant-wrapper's `vagrant.bat` in front of the PATH is:

```
C:\some\path>vagrant up --no-provision --provider=virtualbox
An invalid option was specified. The help for this command
is available below.

Usage: vagrant up [options] [name]

Options:

        --[no-]provision             Enable or disable provisioning
        --provision-with x,y,z       Enable only certain provisioners, by type.
        --[no-]destroy-on-error      Destroy machine if any fatal error happens (default to true)
        --[no-]parallel              Enable or disable parallelism if provider supports it
        --provider PROVIDER          Back the machine with a specific provider
    -h, --help                       Print this help
```

The same command works with plain `vagrant.exe` though. 

For more context see tknerr/sample-toplevel-cookbook#5 where the issue occured.

It seems to be because of using `Shellwords.join(args)` which is intended for [escaping according to UNIX bourne shell rules](http://ruby-doc.org/stdlib-2.0/libdoc/shellwords/rdoc/Shellwords.html) but obviosuly does not work properly on windows.

A first workaround is to bypass `Shellwords.join` completely on Windows. This makes my use case in tknerr/sample-toplevel-cookbook#5 working again, but some more testing would be helpful.

I added back a bit of the shell join functionality by using [this dos_escape](https://github.com/rubyworks/facets/issues/17). My use case still works with this, but again, some more test cases would be helpful.

Another approach would be to use larskanis/shellwords, which seems to provide the functionality for both unix and windows. However, I refrained from that as it could potentially affect the existing behaviour for Linux users. Right now it will only affect Windows users.

@btm wants to chime in?
