### PR TITLE
Remove `Shellwords.join()` and keep ARGV as-is

### DIFF
--- a/lib/vagrant-wrapper.rb
+++ b/lib/vagrant-wrapper.rb
@@ -13,7 +13,6 @@
 #
 
 require 'vagrant-wrapper/exceptions'
-require 'shellwords'
 
 # Main class for the VagrantWrapper driver.
 # This driver will search predefined paths for a packaged version of Vagrant,
@@ -159,7 +158,7 @@ class VagrantWrapper
       return nil
     end
     args.unshift(vagrant)
-    %x{#{Shellwords.join(args)} 2>&1}
+    %x{#{args.join(' ')} 2>&1}
   end
 
   # Give execution control to Vagrant.
@@ -170,7 +169,7 @@ class VagrantWrapper
       exit(1)
     end
     args.unshift(vagrant)
-    exec(Shellwords.join(args))
+    exec(args.join(' '))
   end
 
   def windows?


### PR DESCRIPTION
As per the discussion in #5 this PR removes the shell escaping via `Shellwords.join()` completely rather than trying to make it work on windows.

Why?
- vagrant-wrapper is just a proxy / middle-man
- whatever comes in to vagrant-wrapper should be passed unmodified to vagrant
- if something needs to be shell-escaped that's in the responsibility of the caller, not us

This _might (potentially)_ affect existing linux users, but it should not be a problem:
1. this behaviour is nowhere documented (i.e. not public API) users should not rely on it
2. if something breaks this indicates that callers (probably unknowingly) missed to escape the input properly

/cc
@btm for you to review / test
@binarybabel if @btm agrees we can close #5 in favor of this PR
