### PR TITLE
Directly pass arguments to vagrant (no shell)

### DIFF
--- a/lib/vagrant-wrapper.rb
+++ b/lib/vagrant-wrapper.rb
@@ -168,8 +168,7 @@ class VagrantWrapper
       $stderr.print VagrantWrapper.install_instructions
       exit(1)
     end
-    args.unshift(vagrant)
-    exec(args.join(' '))
+    exec(vagrant, *args)
   end
 
   def windows?


### PR DESCRIPTION
In order to fix #7, I'm just passing the `args` array as exec parameters instead of building a new command line which could be miss-interpreted by the underlying shell exec.