### PR TITLE
support Ruby 1.9+

### DIFF
--- a/lib/vagrant-wrapper.rb
+++ b/lib/vagrant-wrapper.rb
@@ -176,7 +176,9 @@ class VagrantWrapper
   end
 
   def is_wrapper?(file)
-    File.readlines(file).grep(/#{WRAPPER_MARK}/).any?
+    read_mode = (defined? Encoding) ? {:mode => 'r:ASCII-8BIT'} : 'r'
+    
+    File.readlines(file, read_mode).grep(/#{WRAPPER_MARK}/).any?
   end
 
   def path_separator


### PR DESCRIPTION
current master causes error as below

```
gem-vagrant-wrapper/lib/vagrant-wrapper.rb:179:in `===': invalid byte sequence in UTF-8 (ArgumentError)
```
