### PR TITLE
Don't raise errors when run against binary files

### DIFF
--- a/lib/vagrant-wrapper.rb
+++ b/lib/vagrant-wrapper.rb
@@ -70,12 +70,12 @@ class VagrantWrapper
       send("exec_vagrant", *args)
     end
   end
-  
+
   # Return the filesystem location of the discovered Vagrant install.
   def vagrant_location
     find_vagrant
   end
-  
+
   # Return the version of the discovered Vagrant install.
   def vagrant_version
     ver = call_vagrant "-v"
@@ -176,7 +176,7 @@ class VagrantWrapper
   end
 
   def is_wrapper?(file)
-    File.readlines(file).grep(/#{WRAPPER_MARK}/).any?
+    File.binread(file).include?(WRAPPER_MARK)
   end
 
   def path_separator

--- a/spec/vagrant_wrapper_spec.rb
+++ b/spec/vagrant_wrapper_spec.rb
@@ -167,7 +167,7 @@ describe VagrantWrapper do
 
   describe "#is_wrapper?" do
     let(:temp_file) { Tempfile.new('vagrant_wrapper_spec') }
-    
+
     after do
       temp_file.unlink
     end
@@ -180,6 +180,14 @@ describe VagrantWrapper do
 
     it "returns false when the file does not contain the wrapper mark" do
       temp_file.write("This is a temporary file.\nNothing.\nBye.")
+      temp_file.close
+      expect(@v.send(:is_wrapper?, temp_file.path)).to be false
+    end
+
+    it "returns false when the file is binary and does not contain the wrapper mark" do
+      # NOTE: this was taken from the actual header of /opt/vagrant/bin/vagrant on an OS X
+      # system where vagrant had been installed via "brew cask install brew".
+      temp_file.write("\xCF\xFA\xED\xFE\a\u0000\u0000\u0001\u0003\u0000\u0000\u0000\u0002\u0000\u0000\u0000\t\u0000\u0000\u0000H\b\u0000\u0000\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0019\u0000\u0000\u0000H\u0000\u0000\u0000__PAGEZERO\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000")
       temp_file.close
       expect(@v.send(:is_wrapper?, temp_file.path)).to be false
     end


### PR DESCRIPTION
Fixes #9 .

Looks like the problem occurs on the OSX binary (not sure if other systems too).  Things operate fine with this installed.  Tests don't all pass--I see one failure--but said failure occurs before this patch as well, so it's not introduced by this patch.